### PR TITLE
[이연서/auth] 회원가입, 로그인 api / jwt 토큰 인증

### DIFF
--- a/homework/lee-yeonseo/backend/.prettierrc
+++ b/homework/lee-yeonseo/backend/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 120,
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/homework/lee-yeonseo/backend/app.js
+++ b/homework/lee-yeonseo/backend/app.js
@@ -1,8 +1,11 @@
 import express from 'express';
 import cors from 'cors';
+import jwt from 'jsonwebtoken';
 
 const app = express();
 const port = 3000;
+
+const secretKey = 'aksjhdfjkladhfklhjaskl';
 
 const todoItems = [
   {
@@ -23,6 +26,16 @@ const todoItems = [
   },
 ];
 
+const users = [
+  {
+    id: 1,
+    email: 'dldustj0209@naver.com',
+    password: 'd',
+    role: 'student',
+    name: '이연서',
+  },
+];
+
 app.use(cors());
 app.use(express.json());
 
@@ -32,7 +45,13 @@ app.get('/', (req, res) => {
 
 //할 일 목록 조회 api
 app.get('/todo-items', (req, res) => {
-  return res.send(todoItems);
+  const token = req.headers.authorization;
+  try {
+    const user = jwt.verify(token, secretKey);
+    return res.send(todoItems.filter((todoItem) => todoItem.userId === user.id));
+  } catch (error) {
+    return res.status(401).json({ message: '인증정보가 유효하지 않습니다.' });
+  }
 });
 
 //할 일 상세 조회 api
@@ -46,21 +65,26 @@ app.get('/todo-items/:id', (req, res) => {
 //할 일 등록 api
 app.post('/todo-items', (req, res) => {
   const { title } = req.body;
+  const token = req.headers.authorization;
 
-  const newTodoId = todoItems[todoItems.length - 1] ? todoItems[todoItems.length - 1].id + 1 : 1;
+  try {
+    const user = jwt.verify(token, secretKey);
+    const newTodoId = todoItems[todoItems.length - 1] ? todoItems[todoItems.length - 1].id + 1 : 1;
 
-  const newTodoItem = {
-    id: newTodoId,
-    userId: 1,
-    title,
-    doneAt: null,
-    createdAt: new Date(),
-    updatedAt: null,
-  };
+    const newTodoItem = {
+      id: newTodoId,
+      userId: user.id,
+      title,
+      doneAt: null,
+      createdAt: new Date(),
+      updatedAt: null,
+    };
 
-  todoItems.push(newTodoItem);
-
-  return res.send(newTodoItem);
+    todoItems.push(newTodoItem);
+    return res.send(newTodoItem);
+  } catch (error) {
+    return res.status(401).json({ message: '인증정보가 유효하지 않습니다.' });
+  }
 });
 
 //할 일 수정 api
@@ -106,6 +130,49 @@ app.delete('/todo-items/:id', (req, res) => {
   todoItems.splice(todoItemIndex, 1);
 
   return res.send(todoItems);
+});
+
+//회원가입 api
+app.post('/sign-up', (req, res) => {
+  const { email, password, rePassword, role, name } = req.body;
+  if (!email || !password || !rePassword || !role || !name) {
+    return res.status(400).json({ message: '필수 입력값이 누락되었습니다.' });
+  }
+  if (password !== rePassword) {
+    return res.status(400).json({ message: '비밀번호와 비밀번호 확인이 일치하지 않습니다.' });
+  }
+  const existingUser = users.find((user) => user.email === email);
+  if (existingUser) {
+    return res.status(409).json({ message: '이미 가입한 이메일입니다.' });
+  }
+  const id = users.length === 0 ? 1 : users[users.length - 1].id + 1;
+  const newUser = { id, email, password, role, name };
+
+  users.push(newUser);
+  return res.status(200).json({ newUser });
+});
+
+//로그인 api
+app.post('/sign-in', (req, res) => {
+  const { email, password } = req.body;
+  const { password: _pw, ...user } = users.find((user) => user.email === email && user.password === password);
+  if (!user) {
+    return res.status(404).json({ message: '유저를 찾을 수 없습니다.' });
+  }
+  console.log(user);
+  const token = jwt.sign(user, secretKey);
+  return res.status(200).json({ token });
+});
+
+//토큰 검증 api
+app.get('/users/me', (req, res) => {
+  const token = req.headers.authorization;
+  try {
+    const user = jwt.verify(token, secretKey);
+    return res.status(200).json({ user });
+  } catch (error) {
+    return res.status(401).json({ message: '인증정보가 유효하지 않습니다.' });
+  }
 });
 
 app.listen(port, () => {

--- a/homework/lee-yeonseo/backend/package.json
+++ b/homework/lee-yeonseo/backend/package.json
@@ -4,10 +4,13 @@
   "main": "index.js",
   "type": "module",
   "license": "MIT",
-  "scripts": {"dev": "nodemon app.js"},
+  "scripts": {
+    "dev": "nodemon app.js"
+  },
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
     "nodemon": "^3.1.3"
   }
 }

--- a/homework/lee-yeonseo/backend/yarn.lock
+++ b/homework/lee-yeonseo/backend/yarn.lock
@@ -66,6 +66,11 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
 bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
@@ -164,6 +169,13 @@ destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -385,6 +397,74 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+jsonwebtoken@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#65ff91f4abef1784697d40952bb1998c504caaf3"
+  integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^7.5.4"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
+
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -434,7 +514,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -539,7 +619,7 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-safe-buffer@5.2.1:
+safe-buffer@5.2.1, safe-buffer@^5.0.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -549,7 +629,7 @@ safe-buffer@5.2.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semver@^7.5.3:
+semver@^7.5.3, semver@^7.5.4:
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
   integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==


### PR DESCRIPTION
## 수업 내용 정리
>JWT

- `헤더`, `페이로드`, `시그니처`의 세가지로 구성되어있는 문자열.
페이로드에 사용자의 정보가 담겨있다.

- 시크릿키가 없어도 디코딩으로 페이로드에 담긴 사용자의 정보를 알아낼 수 있기때문에 중요한 정보는 넣지 않아야 한다.

- 시크릿키가 있다면 토큰을 위변조할 수 있기 때문에 보안에 주의해야한다.

- 클라이언트는 일반적으로 토큰을 http의 헤더에 넣어서 요청한다.

- `expiresIn`으로 토큰의 유효기간을 정할 수 있다. `(ex: expiresIn: '7d')`

- `jwt.sign( 담을 정보, 시크릿키)`로 토큰을 생성한다.

- `jwt.verify( 검증할 토큰, 시크릿키)`로 토큰을 검증할 수 있다.

- 토큰 검증에 실패할 경우 에러가 생기기 때문에 try...catch를 사용하는 것이 좋다. 

>구조분해할당에서 특정 키만 빼고 할당하기

```
const { password: _pw, ...user } = users.find((user) => user.email === email && user.password === password);

```
찾은 유저의 정보에서 password만 _pw라는 변수에 할당하고, user에 password를 제외한 나머지 정보들을 담아 객체로 만든다.
구조분해할당의 일종
>유효성 검증 순서

![스크린샷 2024-06-07 233551](https://github.com/node3rd-basic/todolist_5th/assets/167045109/35167558-fcd5-404d-a929-0facf461ec0f)
이런식으로 todoItem 조회가 jwt 검증 앞에 위치해 있다면, 만약 jwt유효성 검증에 실패했을 때 안해도 될 item 조회를 먼저 한 것이 되어 리소스를 낭비할 수 있기 때문에
![스크린샷 2024-06-07 233509](https://github.com/node3rd-basic/todolist_5th/assets/167045109/838b72d8-0e78-4b39-bca3-cfd1f277a830)
이런식으로 jwt유효성 검증을 통과한 후 item을 조회하는 것이 좋다.
## 수업 내용을 통해 배운 것
jwt
구조분해할당에서 특정 키만 빼고 할당하기
유효성 검증 순서
## 이해가 가지 않는 내용 정리 및 질문

## 그 밖에 튜터에게 말하고 싶은 내용
